### PR TITLE
Add typescript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+import Vue from "vue";
+export interface ChartOptions {
+  tagName: string;
+}
+export class Chart extends Vue {
+  public constructorType: string;
+  public options: any;
+  public callback: (event: any) => void;
+  public updateArgs: boolean[];
+}
+export default function install(vue: typeof Vue, options?: ChartOptions): void;


### PR DESCRIPTION
I noticed you guys were missing the typescript definition file.  I've never written one personally but took a shot at this.  Seemed to work on my local.

I tested it with the callback and only ever got one arg there, so I assume my definition of having 1 arg in the callback is correct.  I'm not sure what the possible states for the callback arg is, so I just left it as `any`.