### PR TITLE
Add check for 'this.chart' inside watcher

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -31,7 +31,9 @@ const generateVueComponent = function (Highcharts) {
     watch: {
       options: {
         handler (newValue) {
-          this.chart.update(copyObject(newValue, this.deepCopyOnUpdate), ...this.updateArgs)
+          if (this.chart) {
+            this.chart.update(copyObject(newValue, this.deepCopyOnUpdate), ...this.updateArgs)
+          }
         },
         deep: true
       }


### PR DESCRIPTION
We've been getting sentry issues stemming from us having the `options` watcher called before this chart is instantiated. This should resolve it.

![image](https://user-images.githubusercontent.com/1761115/67385597-46499f00-f58b-11e9-94ae-4a44f77bf1ec.png)
 