### PR TITLE
Missed type for the 'chart' variable

### DIFF
--- a/types/highcharts-vue.d.ts
+++ b/types/highcharts-vue.d.ts
@@ -31,6 +31,7 @@ export interface ChartWatchObject {
 }
 
 export class Chart extends _Vue {
+    chart: Highcharts.Chart;
     props: ChartPropsObject;
     template: string;
     watch: ChartWatchObject;


### PR DESCRIPTION
Very quick fix.
There was a missed type for the `this.$refs.chart.chart` variable.