### PR TITLE
Fix bug in onBeforeUnmount where .destroy() is called

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -70,7 +70,7 @@ const generateVueComponent = function (Highcharts, VueVersion) {
     render () { return h('div', { ref: 'chartContainer' }) },
     setup(props) {
       const chartContainer = ref(null),
-        chart = shallowRef({});
+        chart = shallowRef(null);
 
       onMounted(() => {
         let HC = props.highcharts || Highcharts;


### PR DESCRIPTION
Previously the value was null and the if-stmt was sufficient before calling .destroy but since
https://github.com/highcharts/highcharts-vue/pull/236, the if-stmt is always true so it ended up trying to call .destroy() on the empty object.