### PR TITLE
enhancement/vue3-types

### DIFF
--- a/generate_types.js
+++ b/generate_types.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+function getVueVersion() {
+    try {
+        const vuePackageJsonPath = path.resolve(__dirname, '../../vue/package.json');
+        const vuePackageJson = JSON.parse(fs.readFileSync(vuePackageJsonPath, 'utf8'));
+        return vuePackageJson.version;
+    }
+    // if there is an error, return the 3. version by default
+    // todo: think how you can handle it
+    catch (e) {
+        return '3.';
+    }
+}
+
+function generateTypeDefinitions(vueVersion) {
+    let template;
+
+    if (vueVersion.startsWith('2.')) {
+        template = fs.readFileSync(path.join(__dirname, 'types/vue2/highcharts-vue.d.ts'));
+    } else {
+        template = fs.readFileSync(path.join(__dirname, 'types/vue3/highcharts-vue.d.ts'));
+    }
+
+    fs.writeFileSync(path.join(__dirname, 'types/highcharts-vue.d.ts'), template);
+}
+
+const vueVersion = getVueVersion();
+generateTypeDefinitions(vueVersion);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,15 @@
   "version": "1.4.3",
   "description": "Highcharts wrapper Vue component",
   "main": "dist/highcharts-vue.min.js",
-  "typings": "types/highcharts-vue.d.ts",
+  "types": "./types/vue2/highcharts-vue.d.ts",
+  "typesVersions": {
+    "<3.0.0": {
+      "*": ["types/vue2/*"]
+    },
+    ">=3.0.0": {
+      "*": ["types/vue3/*"]
+    }
+  },
   "scripts": {
     "test": "jest",
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,7 @@
   "version": "1.4.3",
   "description": "Highcharts wrapper Vue component",
   "main": "dist/highcharts-vue.min.js",
-  "types": "./types/vue2/highcharts-vue.d.ts",
-  "typesVersions": {
-    "<3.0.0": {
-      "*": ["types/vue2/*"]
-    },
-    ">=3.0.0": {
-      "*": ["types/vue3/*"]
-    }
-  },
+  "typings": "types/highcharts-vue.d.ts",
   "scripts": {
     "test": "jest",
     "build": "webpack",
@@ -21,7 +13,8 @@
     "app-v3": "cd demo-v3 && npx yarn serve",
     "lint": "eslint . --ext .js,.vue",
     "lint:fix": "eslint . --ext .js,.vue --fix",
-    "release": "standard-version"
+    "release": "standard-version",
+    "postinstall": "node generate_types.js"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/types/vue2/highcharts-vue.d.ts
+++ b/types/vue2/highcharts-vue.d.ts
@@ -1,5 +1,5 @@
 import _Vue, { VNode, PropOptions, WatchOptionsWithHandler, WatchHandler, CreateElement } from "vue";
-import * as Highcharts from "highcharts"
+import * as Highcharts from "highcharts";
 
 export type ChartUpdateArgs = [boolean, boolean, Highcharts.AnimationOptionsObject]
 

--- a/types/vue3/highcharts-vue.d.ts
+++ b/types/vue3/highcharts-vue.d.ts
@@ -1,0 +1,31 @@
+// Types for Vue3
+import { DefineComponent, App } from 'vue';
+import * as Highcharts from 'highcharts';
+
+export type ChartUpdateArgs = [boolean, boolean, Highcharts.AnimationOptionsObject];
+
+declare module '@vue/runtime-core' {
+    export interface ComponentCustomProperties {
+        highcharts?: typeof Highcharts;
+    }
+}
+
+export interface ChartComponentOptions {
+    constructorType?: string;
+    options?: Highcharts.Options;
+    callback?: Highcharts.ChartCallbackFunction;
+    updateArgs?: ChartUpdateArgs;
+    highcharts?: typeof Highcharts;
+    deepCopyOnUpdate?: boolean;
+}
+
+export interface ChartProps {
+    constructorType?: string;
+    options: Highcharts.Options;
+    updateArgs?: ChartUpdateArgs;
+    callback?: Highcharts.ChartCallbackFunction;
+}
+
+export const Chart: DefineComponent<ChartProps>;
+
+export default function install(app: App, options?: ChartComponentOptions): void;


### PR DESCRIPTION
Fixed #209, added types for Vue 3.

---
Till now, the `highcharts-vue.d.ts` file included type declarations compatible with Vue 2, but not with Vue 3. The current solution splits the type definitions into 2 files (`types/vue2/highcharts-vue.d.ts` and `types/vue3/highcharts-vue.d.ts`) which are exported depending on the version of that the user has installed. 

---
- [x] add a type declaration file for Vue 3
- [ ] test if the type declaration for Vue 3 throws any errors
- [ ] test whether the proper type declaration file is exported depending on the version of Vue