### PR TITLE
Fix null reference error on update

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -30,10 +30,12 @@ const generateVueComponent = function (Highcharts) {
         watch: {
             options: {
                 handler (newValue) {
-                    this.chart.update(
-                        copyObject(newValue, this.deepCopyOnUpdate),
-                        ...this.updateArgs
-                    );
+                    if (this.chart) {
+                        this.chart.update(
+                            copyObject(newValue, this.deepCopyOnUpdate),
+                            ...this.updateArgs
+                        );
+                    }
                 },
                 deep: true
             }


### PR DESCRIPTION
If you update the `options` props BEFORE the component is mounted, it'll throw an error. This PR prevents that from happening.